### PR TITLE
Replace no-break and figure spaces

### DIFF
--- a/SMSCounter.php
+++ b/SMSCounter.php
@@ -511,6 +511,8 @@ class SMSCounter
           'Ǚ' => 'U', 'ǚ' => 'u',
           // grave accent
           'Ǜ' => 'U', 'ǜ' => 'u',
+          // spaces
+          ' ' => ' ', ' ' => ' ',
         ];
 
         $str = strtr($str, $chars);

--- a/Tests/SMSCounterTest.php
+++ b/Tests/SMSCounterTest.php
@@ -201,6 +201,7 @@ class SMSCounterTest extends TestCase
             ['@£$¥èéùìòÇØøÅåΔ_ΦΓΛΩΠΨΣΘΞ^{}\[~]|€ÆæßÉ!\"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà', '@£$¥èéùìòÇØøÅåΔ_ΦΓΛΩΠΨΣΘΞ^{}\[~]|€ÆæßÉ!\"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà'],
             ['Lhg jjjo fx 382 64237 12299 qmecb. Ç éæ+! -[Å*_ (¡)| ?Λ^ ~£;ΩΠ¿ ÑΔ #ΓüΘ¥ñ,É øΨì] ò= Ü. @å<: ö%\'Æ¤"Ö> Ø§Φ{ }/&Ä ùß\€ èà Ξ$äΣ.', 'Lhg jjjo fx 382 64237 12299 qmecb. Ç éæ+! -[Å*_ (¡)| ?Λ^ ~£;ΩΠ¿ ÑΔ #ΓüΘ¥ñ,É øΨì] ò= Ü. @å<: ö%\'Æ¤"Ö> Ø§Φ{ }/&Ä ùß\€ èà Ξ$äΣ.'],
             ['dadáó', 'dadao'],
+            ["\xc2\xa0|\xe2\x80\x87|\xef\xbb\xbf", ' | |'],
         ];
     }
 }


### PR DESCRIPTION
This patch ensures that no-break, figure and zero-width spaces are replaced correctly. These spaces are sometimes used to format phone numbers or monetary values.