### PR TITLE
Support GSM National Language Shift Tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ use Instasent\SMSCounter\SMSCounter;
 
 $smsCounter = new SMSCounter();
 $smsCounter->count('some-string-to-be-counted');
+$smsCounter->countWithShiftTables('some-string-to-be-counted');
 ```
 
 which returns
@@ -26,7 +27,7 @@ stdClass Object
 )
 ```
 
-You can sanitize your text to be a valid GSM 03.38 charset
+You can sanitize your text to be a valid strict GSM 03.38 charset
 
 ```php
 use Instasent\SMSCounter\SMSCounter;
@@ -34,6 +35,15 @@ use Instasent\SMSCounter\SMSCounter;
 $smsCounter = new SMSCounter();
 $smsCounter->sanitizeToGSM('dadáó'); //return dadao
 ```
+
+#### National Language Shift Tables
+
+Starting release 8 of GSM 03.38 some additional charsets are allowed. This is the list of such National Language Shift Tables currently supported
+
+- [Turkish](https://en.wikipedia.org/wiki/GSM_03.38#Turkish_language_(Latin_script))
+- [Spanish](https://en.wikipedia.org/wiki/GSM_03.38#Spanish_language_(Latin_script))
+- [Portuguese](https://en.wikipedia.org/wiki/GSM_03.38#Portuguese_language_(Latin_script))
+
 
 ## Installation
 

--- a/Tests/SMSCounterTest.php
+++ b/Tests/SMSCounterTest.php
@@ -24,6 +24,57 @@ class SMSCounterTest extends TestCase
         $this->assertEquals($expected, $count);
     }
 
+    public function testGSM_TR()
+    {
+        $text = 'a GSM TR ç Text';
+
+        $smsCounter = new SMSCounter();
+        $count = $smsCounter->countWithShiftTables($text);
+
+        $expected = new \stdClass();
+        $expected->encoding = SMSCounter::GSM_7BIT_EX;
+        $expected->length = 16;
+        $expected->per_message = 160;
+        $expected->remaining = 144;
+        $expected->messages = 1;
+
+        $this->assertEquals($expected, $count);
+    }
+
+    public function testGSM_ES()
+    {
+        $text = 'a GSM ES Ú Text';
+
+        $smsCounter = new SMSCounter();
+        $count = $smsCounter->countWithShiftTables($text);
+
+        $expected = new \stdClass();
+        $expected->encoding = SMSCounter::GSM_7BIT_EX;
+        $expected->length = 16;
+        $expected->per_message = 160;
+        $expected->remaining = 144;
+        $expected->messages = 1;
+
+        $this->assertEquals($expected, $count);
+    }
+
+    public function testGSM_PT()
+    {
+        $text = 'a GSM PT Ã Text';
+
+        $smsCounter = new SMSCounter();
+        $count = $smsCounter->countWithShiftTables($text);
+
+        $expected = new \stdClass();
+        $expected->encoding = SMSCounter::GSM_7BIT_EX;
+        $expected->length = 16;
+        $expected->per_message = 160;
+        $expected->remaining = 144;
+        $expected->messages = 1;
+
+        $this->assertEquals($expected, $count);
+    }
+
     public function testGSMSymbols()
     {
         $text = 'a GSM +Text';
@@ -162,6 +213,17 @@ class SMSCounterTest extends TestCase
         $this->assertEquals($expectedTExt, $output);
     }
 
+    public function testTruncate1SmsGSM7ShiftTable()
+    {
+        $text = 'ÚLorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.';
+        $expectedTExt = 'ÚLorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturien';
+
+        $smsCounter = new SMSCounter();
+        $output = $smsCounter->truncateWithShiftTables($text, 1);
+
+        $this->assertEquals($expectedTExt, $output);
+    }
+
     public function testTruncate2SmsGSM7()
     {
         $text = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient';
@@ -169,6 +231,17 @@ class SMSCounterTest extends TestCase
 
         $smsCounter = new SMSCounter();
         $output = $smsCounter->truncate($text, 2);
+
+        $this->assertEquals($expectedTExt, $output);
+    }
+
+    public function testTruncate2SmsGSM7ShiftTable()
+    {
+        $text = 'çLorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturie';
+        $expectedTExt = 'çLorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magni';
+
+        $smsCounter = new SMSCounter();
+        $output = $smsCounter->truncateWithShiftTables($text, 2);
 
         $this->assertEquals($expectedTExt, $output);
     }


### PR DESCRIPTION
Support for GSM Language Shift Tables, information can be found here: en.wikipedia.org/wiki/GSM_03.38

Added support for Turkish, Spanish and Portuguese only, should be fairly easy to extended for other languages