### PR TITLE
Convert "Right Single Quotation Mark" to "Single Quotation Mark"

### DIFF
--- a/SMSCounter.php
+++ b/SMSCounter.php
@@ -689,6 +689,8 @@ class SMSCounter
           'Ǚ' => 'U', 'ǚ' => 'u',
           // grave accent
           'Ǜ' => 'U', 'ǜ' => 'u',
+          // Right Single Quotation Mark
+          '’' => '\'',
           // spaces
           ' ' => ' ', ' ' => ' ',
         ];

--- a/Tests/SMSCounterTest.php
+++ b/Tests/SMSCounterTest.php
@@ -372,6 +372,7 @@ class SMSCounterTest extends TestCase
             ['@£$¥èéùìòÇØøÅåΔ_ΦΓΛΩΠΨΣΘΞ^{}\[~]|€ÆæßÉ!\"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà', '@£$¥èéùìòÇØøÅåΔ_ΦΓΛΩΠΨΣΘΞ^{}\[~]|€ÆæßÉ!\"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà'],
             ['Lhg jjjo fx 382 64237 12299 qmecb. Ç éæ+! -[Å*_ (¡)| ?Λ^ ~£;ΩΠ¿ ÑΔ #ΓüΘ¥ñ,É øΨì] ò= Ü. @å<: ö%\'Æ¤"Ö> Ø§Φ{ }/&Ä ùß\€ èà Ξ$äΣ.', 'Lhg jjjo fx 382 64237 12299 qmecb. Ç éæ+! -[Å*_ (¡)| ?Λ^ ~£;ΩΠ¿ ÑΔ #ΓüΘ¥ñ,É øΨì] ò= Ü. @å<: ö%\'Æ¤"Ö> Ø§Φ{ }/&Ä ùß\€ èà Ξ$äΣ.'],
             ['dadáó', 'dadao'],
+            ['Un rêve de l’aperçu', 'Un reve de l\'apercu'],
             ["\xc2\xa0|\xe2\x80\x87|\xef\xbb\xbf", ' | |'],
         ];
     }


### PR DESCRIPTION
`’` to `'`